### PR TITLE
Added @run-at document-start to handle white flash

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@
 // @description  Simple Dark Mode Stylesheet for HN.
 // @match        https://news.ycombinator.com/*
 // @grant        All
+// @run-at       document-start
 // ==/UserScript==
 
 (function() {


### PR DESCRIPTION
When navigating between pages on HN, a white flash (aka "flash of unstyled content") would appear when using HNDarkMode in Safari. Adding `@run-at document-start` resolved the issue. See https://github.com/darkreader/darkreader/issues/469#issuecomment-1327932311 and https://stackoverflow.com/questions/19385698/how-to-change-a-class-css-with-a-greasemonkey-tampermonkey-script/19392142#19392142 .